### PR TITLE
additional check for existance of file

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -44,8 +44,11 @@ ExtraneousFileCleanupPlugin.prototype.removeFromWebpackStats = (compilation, ass
 
 ExtraneousFileCleanupPlugin.prototype.removeAsset = (compilation, outputPath, assetKey, extension = '') => {
   // remove from various places
-  fs.unlinkSync(outputPath + '/' + assetKey + extension)          // unlink the asset
-  delete compilation.assets[assetKey]                 // remove from webpack output
+  try {
+    fs.unlinkSync(outputPath + '/' + assetKey + extension)          // unlink the asset
+    delete compilation.assets[assetKey]                 // remove from webpack output
+  } catch (e) { }
+
 }
 
 ExtraneousFileCleanupPlugin.prototype.apply = function (compiler) {
@@ -69,8 +72,16 @@ ExtraneousFileCleanupPlugin.prototype.apply = function (compiler) {
       if (!this.validExtension(assetKey)) {
         return
       }
+
+      // Sometimes the file doesn't exists. Not really sure why. Return from function if it doesn't exist
+      // statSync assumes the file exits and will throw an error otherwise
+      const file = outputPath + '/' + assetKey;
+      if (!fs.existsSync(file)) {
+        return
+      }
+
       // if it passes min byte check, ignore it
-      assetStat = fs.statSync(outputPath + '/' + assetKey)
+      assetStat = fs.statSync(file)
       if (assetStat.size > this.minBytes) {
         return
       }
@@ -86,9 +97,7 @@ ExtraneousFileCleanupPlugin.prototype.apply = function (compiler) {
       this.removeAsset(compilation, outputPath, assetKey)
 
       // remove map file from various places if it exists
-      try {
-        this.removeAsset(compilation, outputPath, assetKey, '.map')
-      } catch (e) {}
+      this.removeAsset(compilation, outputPath, assetKey, '.map')
 
       if (usingManifestJson) {
         for (manifestKey in manifestJson) {


### PR DESCRIPTION
I found that sometimes the file doesn't exists. This seems to be true only for some files and only when I'm using webpack --watch. I'm not really sure of the root cause of this; however, I thought it would be good to have an additional check for the existence of the file. Without this, fs.statSync throws an error when it tries to get stats on a file that doesn't exist. 