### PR TITLE
Fix issue with Webpack 4.1.1

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -35,7 +35,7 @@ ExtraneousFileCleanupPlugin.prototype.removeFromWebpackStats = (compilation, ass
 
     for (let j = 0, jLen = compilation.chunks[i].files.length; j < jLen; j++) {
       if (compilation.chunks[i].files[j] === assetKey) {
-        delete compilation.chunks[i]
+        compilation.chunks.splice(i,1);
         return
       }
     }


### PR DESCRIPTION
Hi, 

I've been getting the following error when using this plugin on Webpack 4.1.1

```
.../node_modules/webpack/lib/Stats.js:368
				for (const asset of chunk.files) {
				                          ^

TypeError: Cannot read property 'files' of undefined
```

It looks as if when your code calls `delete compilation.chunks[i]` instead of removing that item from the array, it just makes it `undefined` to correctly remove from the array I've changed it to `splice` the array and modify it in-place.

This fixes the issue.